### PR TITLE
Allow admins through employee/customer middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-const protectedPrefixes: Record<string, Array<'admin' | 'employee' | 'customer'>> = {
+type Role = 'admin' | 'employee' | 'customer';
+
+const protectedPrefixes: Record<string, Role[]> = {
   '/admin': ['admin'],
   '/employee': ['employee', 'admin'],
   '/customer': ['customer', 'admin'],
@@ -12,8 +14,10 @@ const ROLE_COOKIE_NAME = 'bbd-role';
 export function middleware(request: NextRequest) {
   for (const [prefix, allowedRoles] of Object.entries(protectedPrefixes)) {
     if (request.nextUrl.pathname.startsWith(prefix)) {
-      const cookieRole = request.cookies.get(ROLE_COOKIE_NAME)?.value?.toLowerCase();
-      if (!cookieRole || !allowedRoles.includes(cookieRole as typeof allowedRoles[number])) {
+      const cookieRoles = parseRoles(request.cookies.get(ROLE_COOKIE_NAME)?.value);
+      const hasRequiredRole = allowedRoles.some((role) => cookieRoles.has(role));
+
+      if (!hasRequiredRole) {
         const loginUrl = new URL('/login', request.url);
         loginUrl.searchParams.set('next', request.nextUrl.pathname);
         loginUrl.searchParams.set('requiredRole', allowedRoles.join(','));
@@ -24,6 +28,39 @@ export function middleware(request: NextRequest) {
   }
 
   return NextResponse.next();
+}
+
+function parseRoles(rawRole: string | undefined): Set<Role> {
+  if (!rawRole) {
+    return new Set();
+  }
+
+  const normalized = rawRole.trim();
+
+  try {
+    const parsed = JSON.parse(normalized);
+    if (Array.isArray(parsed)) {
+      return new Set<Role>(
+        parsed
+          .filter((value): value is string => typeof value === 'string')
+          .map((value) => value.toLowerCase())
+          .filter(isRole),
+      );
+    }
+  } catch (error) {
+    // Ignore JSON parse errors and fall back to comma separated parsing.
+  }
+
+  return new Set<Role>(
+    normalized
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter(isRole),
+  );
+}
+
+function isRole(value: string): value is Role {
+  return value === 'admin' || value === 'employee' || value === 'customer';
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- align the middleware role guard with the layout allow lists so admins can access employee and customer areas
- support JSON array and comma-separated role cookies when validating access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e69b9d787483338ace5d72ac866f54