### PR TITLE
Fix AI workbench fallback copy generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log*
 
 # Docker artifacts
 docker/*.log
+tsconfig.tsbuildinfo

--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -11,8 +11,20 @@ import { generateProductDescriptions } from '@/lib/ai/local-processing';
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const descriptions = await generateProductDescriptions(body);
-    return NextResponse.json({ data: descriptions });
+    const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : undefined;
+
+    if (!prompt && !body.name) {
+      return NextResponse.json({ error: 'A prompt or product name is required.' }, { status: 400 });
+    }
+
+    const result = await generateProductDescriptions({
+      name: typeof body.name === 'string' ? body.name : undefined,
+      ingredients: typeof body.ingredients === 'string' ? body.ingredients : undefined,
+      mood: typeof body.mood === 'string' ? body.mood : undefined,
+      prompt,
+    });
+
+    return NextResponse.json({ result });
   } catch (error: any) {
     console.error('AI Generation Error:', error);
     return NextResponse.json({ error: 'Failed to generate descriptions' }, { status: 500 });

--- a/lib/ai/local-processing.ts
+++ b/lib/ai/local-processing.ts
@@ -1,4 +1,11 @@
-export async function generateProductDescriptions(productData: { name: string; ingredients?: string; mood?: string }) {
+type ProductCopyInput = {
+  name?: string;
+  ingredients?: string;
+  mood?: string;
+  prompt?: string;
+};
+
+export async function generateProductDescriptions(productData: ProductCopyInput) {
   if (typeof window !== 'undefined' && 'ai' in window) {
     const win = window as typeof window & {
       ai?: {
@@ -16,10 +23,45 @@ export async function generateProductDescriptions(productData: { name: string; i
   return templateBasedGeneration(productData);
 }
 
-function templateBasedGeneration(productData: { name: string; ingredients?: string; mood?: string }) {
-  const { name, ingredients, mood } = productData;
-  const base = `${name} is hand-crafted to transform your bathroom into a sanctuary.`;
-  const ingredientLine = ingredients ? ` Infused with ${ingredients},` : ' Infused with botanical extracts,';
-  const moodLine = mood ? ` it evokes a sense of ${mood}.` : ' it wraps you in serene comfort.';
-  return `${base}${ingredientLine}${moodLine} Enjoy complimentary mindfulness prompts within every ritual.`;
+function templateBasedGeneration({ name, ingredients, mood, prompt }: ProductCopyInput) {
+  const displayName = formatName(name) ?? 'Your ritual';
+  const ingredientLine = formatOptionalLine(ingredients, ' Infused with botanical extracts,');
+  const moodLine = formatOptionalLine(mood, ' it wraps you in serene comfort.', (value) => ` it evokes a sense of ${value}.`);
+  const promptLine = prompt?.trim()
+    ? ` Inspired by the request, we emphasise ${summarisePrompt(prompt)}.`
+    : '';
+
+  return `${displayName} is hand-crafted to transform your bathroom into a sanctuary.${ingredientLine}${moodLine}${promptLine} Enjoy complimentary mindfulness prompts within every ritual.`;
+}
+
+function formatName(name?: string) {
+  if (!name) return null;
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
+function formatOptionalLine(
+  value: string | undefined,
+  fallback: string,
+  formatter: (value: string) => string = (val) => ` Infused with ${val},`,
+) {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  return formatter(trimmed);
+}
+
+function summarisePrompt(prompt: string) {
+  const cleaned = prompt.trim();
+  if (cleaned.length <= 120) {
+    return cleaned;
+  }
+  return `${cleaned.slice(0, 117)}...`;
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bubblingbathdelights",
   "version": "2.0.0",
   "private": true,
+  "packageManager": "npm@11.4.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -14,12 +18,35 @@
     "esModuleInterop": true,
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"],
-      "@/app/*": ["app/*"]
+      "@/components/*": [
+        "components/*"
+      ],
+      "@/lib/*": [
+        "lib/*"
+      ],
+      "@/app/*": [
+        "app/*"
+      ]
     },
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.mts",
+    "**/*.cts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "dev": {
       "cache": false,
       "persistent": false


### PR DESCRIPTION
## Summary
- make the local AI copy generator resilient to free-form prompts and missing product metadata
- align `/api/ai/generate` with the improved generator and validate incoming requests before responding
- harden the admin AI workbench client request handling and prevent empty submissions, while ignoring TypeScript build info artifacts

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f25dd1eb888333b3d443d94a9a78cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI generator accepts an optional freeform prompt alongside product fields and applies improved formatting for outputs.

* **Bug Fixes**
  * Better input validation prevents empty requests and trims prompts before sending.
  * Improved error reporting for AI failures and more reliable button disabling to avoid invalid submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->